### PR TITLE
Remove access logs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,7 +12,6 @@ http {
   server {
     listen 3128;
 
-    access_log /dev/stdout;
     error_log  /dev/stderr;
 
     resolver 1.1.1.1 ipv6=off;


### PR DESCRIPTION
## What does this PR do?
  - It removes the sentence where the access_logs are saved. This step was made because of the DDoS attack the hard disk was filled, and that made the sever useless.
## What could it affect?
  - Logs saved.
## Does it add/upgrade dependencies? (Y/N)
  - N.