### PR TITLE
Ft/nginx restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ $ docker run --rm -d -p 3128:3128 hinata/nginx-forward-proxy:latest
 $ curl -x http://127.0.0.1:3128 https://www.google.co.jp
 ```
 
+Preferably to add the following statement to the OS cron jobs to execute the restart_nginx.py script every 15 minutes, and visualize some log messages from restar_nginx_logs.txt:
+
+```
+*/15 * * * * /usr/bin/env python3 /home/ubuntu/nginx-forward-proxy/restart_nginx.py >> /home/ubuntu/nginx-forward-proxy/restar_nginx_logs.txt
+```
+
+
 ## See also
 
 - https://github.com/chobits/ngx_http_proxy_connect_module

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes auto;
 
 events {
-  worker_connections 10000;
+  worker_connections 20000;
 }
 
 http {

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,7 +12,8 @@ http {
   server {
     listen 3128;
 
-    error_log  /dev/stderr;
+    access_log off;
+    error_log  off;
 
     resolver 1.1.1.1 ipv6=off;
 

--- a/restart_nginx.py
+++ b/restart_nginx.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import re
+import datetime
 
 docker_image = 'reservamos/nginx-forward-proxy:latest'
 pattern = '/dev/xvda1(\s+[0-9.]+G){3}\s+(\d+)%\s\/'
@@ -43,3 +44,5 @@ process = subprocess.Popen(['docker', 'run', '--rm', '-d', '-p', '80:3128', dock
                             universal_newlines=True)
 stdout, stderr = process.communicate()
 print(stdout, stderr)
+
+print('Nginx restart done on {}'.format(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))

--- a/restart_nginx.py
+++ b/restart_nginx.py
@@ -6,6 +6,7 @@ import datetime
 
 docker_image = 'reservamos/nginx-forward-proxy:latest'
 pattern = '/dev/xvda1(\s+[0-9.]+G){3}\s+(\d+)%\s\/'
+HARD_DISK_USAGE_PERCENTAGE_LIMIT = 80
 
 # Inspect hard disk usage.
 process = subprocess.Popen(['df', '-h'],
@@ -17,7 +18,7 @@ stdout, stderr = process.communicate()
 matches = re.search(pattern, stdout)
 hard_disk_use_percentage = int(matches.group(2))
 
-if hard_disk_use_percentage < 80:
+if hard_disk_use_percentage < HARD_DISK_USAGE_PERCENTAGE_LIMIT:
     exit()
 
 # Get all docker container ids.

--- a/restart_nginx.py
+++ b/restart_nginx.py
@@ -1,7 +1,12 @@
+#!/usr/bin/env python3
+
 import subprocess
 import re
 
+docker_image = 'reservamos/nginx-forward-proxy:latest'
 pattern = '/dev/xvda1(\s+[0-9.]+G){3}\s+(\d+)%'
+
+# Inspect hard disk usage.
 process = subprocess.Popen(['df', '-h'],
                      stdout=subprocess.PIPE,
                      stderr=subprocess.PIPE,
@@ -9,11 +14,12 @@ process = subprocess.Popen(['df', '-h'],
 stdout, stderr = process.communicate()
 
 matches = re.search(pattern, stdout)
-use_percentage = int(matches.group(2))
+hard_disk_use_percentage = int(matches.group(2))
 
-if use_percentage < 80:
+if hard_disk_use_percentage < 80:
     exit()
 
+# Get all docker container ids.
 process = subprocess.Popen(['docker', 'ps', '-q'],
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
@@ -22,14 +28,16 @@ stdout, stderr = process.communicate()
 docker_process_ids = stdout.split('\n')[0:-1]
 
 for docker_process_id in docker_process_ids:
+    # Stop docker process with specific id.
     process = subprocess.Popen(['docker', 'stop', docker_process_id],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 universal_newlines=True)
     stdout, stderr = process.communicate()
-    print(stdout)
+    print(stdout, stderr)
 
-process = subprocess.Popen(['docker', 'run', '--rm', '-d', '-p', '80:3128', 'reservamos/nginx-forward-proxy:latest'],
+# Initialize nginx-forward-proxy container.
+process = subprocess.Popen(['docker', 'run', '--rm', '-d', '-p', '80:3128', docker_image],
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             universal_newlines=True)

--- a/restart_nginx.py
+++ b/restart_nginx.py
@@ -34,4 +34,4 @@ process = subprocess.Popen(['docker', 'run', '--rm', '-d', '-p', '80:3128', 'res
                             stderr=subprocess.PIPE,
                             universal_newlines=True)
 stdout, stderr = process.communicate()
-print(stderr)
+print(stdout, stderr)

--- a/restart_nginx.py
+++ b/restart_nginx.py
@@ -1,0 +1,37 @@
+import subprocess
+import re
+
+pattern = '/dev/xvda1(\s+[0-9.]+G){3}\s+(\d+)%'
+process = subprocess.Popen(['df', '-h'],
+                     stdout=subprocess.PIPE,
+                     stderr=subprocess.PIPE,
+                     universal_newlines=True)
+stdout, stderr = process.communicate()
+
+matches = re.search(pattern, stdout)
+use_percentage = int(matches.group(2))
+
+if use_percentage < 80:
+    exit()
+
+process = subprocess.Popen(['docker', 'ps', '-q'],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True)
+stdout, stderr = process.communicate()
+docker_process_ids = stdout.split('\n')[0:-1]
+
+for docker_process_id in docker_process_ids:
+    process = subprocess.Popen(['docker', 'stop', docker_process_id],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True)
+    stdout, stderr = process.communicate()
+    print(stdout)
+
+process = subprocess.Popen(['docker', 'run', '--rm', '-d', '-p', '80:3128', 'reservamos/nginx-forward-proxy:latest'],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True)
+stdout, stderr = process.communicate()
+print(stderr)

--- a/restart_nginx.py
+++ b/restart_nginx.py
@@ -4,7 +4,7 @@ import subprocess
 import re
 
 docker_image = 'reservamos/nginx-forward-proxy:latest'
-pattern = '/dev/xvda1(\s+[0-9.]+G){3}\s+(\d+)%'
+pattern = '/dev/xvda1(\s+[0-9.]+G){3}\s+(\d+)%\s\/'
 
 # Inspect hard disk usage.
 process = subprocess.Popen(['df', '-h'],


### PR DESCRIPTION
## What does this PR do?
  - It adds a python script that checks if it is necessary to restart the container nginx-forward-proxy every 15 minutes. In the nginx configs the log statements are put again to express explicitly they are disabled.
## What could it affect?
  - Generally the proxy.
## Does it add/upgrade dependencies? (Y/N)
  - N.