### PR TITLE
sends error and access logs to /dev/null

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes auto;
 
 events {
-  worker_connections 20000;
+  worker_connections 40000;
 }
 
 http {
@@ -12,8 +12,8 @@ http {
   server {
     listen 3128;
 
-    access_log off;
-    error_log  off;
+    access_log /dev/null;
+    error_log  /dev/null;
 
     resolver 1.1.1.1 ipv6=off;
 


### PR DESCRIPTION
## What does this PR do?
  - Increases number of workers 
  - Sends logs to `dev/null` 
## What could it affect?
  - Generally the proxy.
## Does it add/upgrade dependencies? (Y/N)
  - N.